### PR TITLE
Splashscreen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,8 +29,7 @@
         <activity
             android:name=".activities.SplashScreenActivity"
             android:noHistory="true"
-            android:screenOrientation="sensorPortrait"
-            android:theme="@android:style/Theme.Translucent">
+            android:screenOrientation="sensorPortrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/app/src/main/java/ie/teamchile/smartapp/activities/AboutActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/AboutActivity.java
@@ -3,9 +3,9 @@ package ie.teamchile.smartapp.activities;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.text.util.Linkify;
 import android.util.Log;
 import android.view.View;
+import android.view.WindowManager;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -20,6 +20,7 @@ public class AboutActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentView(R.layout.activity_about);
 
         progressBar = (ProgressBar) findViewById(R.id.pb_webview);

--- a/app/src/main/java/ie/teamchile/smartapp/activities/AppointmentCalendarActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/AppointmentCalendarActivity.java
@@ -13,6 +13,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.BaseAdapter;
 import android.widget.Button;
 import android.widget.DatePicker;
@@ -63,6 +64,7 @@ public class AppointmentCalendarActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentForNav(R.layout.activity_appointment_calendar);
 
         Log.d("bugs", "clinicSelected = " + clinicSelected);

--- a/app/src/main/java/ie/teamchile/smartapp/activities/AppointmentTypeSpinnerActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/AppointmentTypeSpinnerActivity.java
@@ -5,8 +5,10 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.os.CountDownTimer;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
@@ -47,12 +49,13 @@ public class AppointmentTypeSpinnerActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentForNav(R.layout.activity_appointment_type_spinner);
 
         c.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
         Log.d("MYLOG", "Date set to " + c.getTime());
 
-        spinnerWarning = getResources().getColor(R.color.spinner_warning);
+        spinnerWarning = ContextCompat.getColor(this, R.color.spinner_warning);
 
         tvAppointmentType = (TextView) findViewById(R.id.tv_appointment_type);
         tvServiceOption = (TextView) findViewById(R.id.tv_service_option);

--- a/app/src/main/java/ie/teamchile/smartapp/activities/BaseActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/BaseActivity.java
@@ -24,6 +24,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
@@ -95,6 +96,7 @@ public class BaseActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentView(R.layout.navigation_drawer_layout);
 
         spinnerWarning = getResources().getColor(R.color.teal);

--- a/app/src/main/java/ie/teamchile/smartapp/activities/ClinicTimeRecordActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/ClinicTimeRecordActivity.java
@@ -7,6 +7,7 @@ import android.os.CountDownTimer;
 import android.os.Vibrator;
 import android.util.Log;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -73,6 +74,7 @@ public class ClinicTimeRecordActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentForNav(R.layout.activity_clinic_time_record);
         c = Calendar.getInstance();
         todayDay = dfDayLong.format(c.getTime());

--- a/app/src/main/java/ie/teamchile/smartapp/activities/CreateAppointmentActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/CreateAppointmentActivity.java
@@ -12,6 +12,7 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
@@ -74,6 +75,7 @@ public class CreateAppointmentActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentForNav(R.layout.activity_create_appointment);
 
         c = Calendar.getInstance();

--- a/app/src/main/java/ie/teamchile/smartapp/activities/HomeVisitAppointmentActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/HomeVisitAppointmentActivity.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.BaseAdapter;
 import android.widget.Button;
 import android.widget.DatePicker;
@@ -54,6 +55,7 @@ public class HomeVisitAppointmentActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentForNav(R.layout.activity_home_visit_appointment);
 
         dateInList = (Button) findViewById(R.id.btn_date);

--- a/app/src/main/java/ie/teamchile/smartapp/activities/LoginActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/LoginActivity.java
@@ -8,6 +8,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -41,6 +42,7 @@ public class LoginActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentView(R.layout.activity_login);
 
         checkForUpdates();
@@ -137,8 +139,8 @@ public class LoginActivity extends AppCompatActivity {
         username = tvUsername.getText().toString();
         password = tvPassword.getText().toString();
 
-        if(!TextUtils.isEmpty(username) &&
-                !TextUtils.isEmpty(password)){
+        if (!TextUtils.isEmpty(username) &&
+                !TextUtils.isEmpty(password)) {
             postLogin();
             pd = new CustomDialogs().showProgressDialog(
                     LoginActivity.this,

--- a/app/src/main/java/ie/teamchile/smartapp/activities/MidwiferyLogActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/MidwiferyLogActivity.java
@@ -53,6 +53,7 @@ public class MidwiferyLogActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentForNav(R.layout.activity_midwifery_log);
 
         setActionBarTitle(getResources().getString(R.string.midwifery_log));

--- a/app/src/main/java/ie/teamchile/smartapp/activities/ParityDetailsActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/ParityDetailsActivity.java
@@ -10,6 +10,7 @@ import android.view.Display;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.BaseAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
@@ -49,6 +50,7 @@ public class ParityDetailsActivity extends BaseActivity {
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
 		setContentForNav(R.layout.activity_parity_details);
 		/*lvParity = (ListView)findViewById(R.id.lv_parity);*/
 		rvParity = (RecyclerView) findViewById(R.id.rv_parity);

--- a/app/src/main/java/ie/teamchile/smartapp/activities/QuickMenuActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/QuickMenuActivity.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.os.CountDownTimer;
 import android.util.Log;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.Button;
 
 import java.util.ArrayList;
@@ -36,6 +37,7 @@ public class QuickMenuActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentForNav(R.layout.activity_quick_menu);
 
         Log.d("bugs", "quick menu in on create");

--- a/app/src/main/java/ie/teamchile/smartapp/activities/ServiceUserActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/ServiceUserActivity.java
@@ -15,6 +15,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.BaseAdapter;
@@ -95,6 +96,7 @@ public class ServiceUserActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentForNav(R.layout.activity_service_user_tabhost);
         TabHost tabHost = (TabHost) findViewById(android.R.id.tabhost);
         tabHost.setup();

--- a/app/src/main/java/ie/teamchile/smartapp/activities/ServiceUserSearchActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/ServiceUserSearchActivity.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
@@ -53,6 +54,7 @@ public class ServiceUserSearchActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentForNav(R.layout.activity_service_user_search);
 
         searchName = (EditText) findViewById(R.id.et_search_name);

--- a/app/src/main/java/ie/teamchile/smartapp/activities/SplashScreenActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/SplashScreenActivity.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.WindowManager;
 
 import ie.teamchile.smartapp.model.BaseModel;
 import ie.teamchile.smartapp.util.CheckForRoot;
@@ -14,6 +15,7 @@ public class SplashScreenActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
 
         Log.d("isDeviceRooted", "isDeviceRooted() = " + new CheckForRoot().isDeviceRooted());
 

--- a/app/src/main/java/ie/teamchile/smartapp/activities/SplashScreenActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/SplashScreenActivity.java
@@ -4,21 +4,34 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.View;
 import android.view.WindowManager;
+import android.widget.Button;
 
+import ie.teamchile.smartapp.R;
 import ie.teamchile.smartapp.model.BaseModel;
 import ie.teamchile.smartapp.util.CheckForRoot;
 
-public class SplashScreenActivity extends Activity {
+public class SplashScreenActivity extends Activity implements View.OnClickListener {
     private String rootMsg;
+    private Button btnYes;
+    private Button btnNo;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
+        setContentView(R.layout.activity_splash_screen);
+
+        btnYes = (Button) findViewById(R.id.btn_yes);
+        btnYes.setOnClickListener(this);
+        btnNo = (Button) findViewById(R.id.btn_no);
+        btnNo.setOnClickListener(this);
 
         Log.d("isDeviceRooted", "isDeviceRooted() = " + new CheckForRoot().isDeviceRooted());
+    }
 
+    private void checkIfLoggedIn() {
         if (BaseModel.getInstance().getLoginStatus()) {
             Log.d("bugs", "logged in = " + BaseModel.getInstance().getLoginStatus());
             Intent intent = new Intent(SplashScreenActivity.this, QuickMenuActivity.class);
@@ -27,6 +40,18 @@ public class SplashScreenActivity extends Activity {
             Log.d("bugs", "logged in = " + BaseModel.getInstance().getLoginStatus());
             Intent intent = new Intent(SplashScreenActivity.this, LoginActivity.class);
             startActivity(intent);
+        }
+    }
+
+    @Override
+    public void onClick(View v) {
+        switch (v.getId()) {
+            case R.id.btn_yes:
+                checkIfLoggedIn();
+                break;
+            case R.id.btn_no:
+                finish();
+                break;
         }
     }
 }

--- a/app/src/main/java/ie/teamchile/smartapp/activities/SplashScreenActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/SplashScreenActivity.java
@@ -3,19 +3,26 @@ package ie.teamchile.smartapp.activities;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.text.format.DateUtils;
 import android.util.Log;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.Button;
 
+import java.util.Calendar;
+
 import ie.teamchile.smartapp.R;
 import ie.teamchile.smartapp.model.BaseModel;
 import ie.teamchile.smartapp.util.CheckForRoot;
+import ie.teamchile.smartapp.util.Constants;
+import ie.teamchile.smartapp.util.SharedPrefs;
 
 public class SplashScreenActivity extends Activity implements View.OnClickListener {
     private String rootMsg;
     private Button btnYes;
     private Button btnNo;
+    private SharedPrefs sharedPrefs = new SharedPrefs();
+    private Calendar c = Calendar.getInstance();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -27,6 +34,15 @@ public class SplashScreenActivity extends Activity implements View.OnClickListen
         btnYes.setOnClickListener(this);
         btnNo = (Button) findViewById(R.id.btn_no);
         btnNo.setOnClickListener(this);
+
+        long time = sharedPrefs.getLongPrefs(this, Constants.SHARED_PREFS_SPLASH_LOG);
+
+        if(time != 0) {
+            if (DateUtils.isToday(time))
+                checkIfLoggedIn();
+            else
+                sharedPrefs.setLongPrefs(this, c.getTimeInMillis(), Constants.SHARED_PREFS_SPLASH_LOG);
+        }
 
         Log.d("isDeviceRooted", "isDeviceRooted() = " + new CheckForRoot().isDeviceRooted());
     }

--- a/app/src/main/java/ie/teamchile/smartapp/activities/TodayAppointmentActivity.java
+++ b/app/src/main/java/ie/teamchile/smartapp/activities/TodayAppointmentActivity.java
@@ -1,11 +1,13 @@
 package ie.teamchile.smartapp.activities;
 
 import android.os.Bundle;
+import android.view.WindowManager;
 
 public class TodayAppointmentActivity extends BaseActivity   {
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
 	}
 }

--- a/app/src/main/java/ie/teamchile/smartapp/util/Constants.java
+++ b/app/src/main/java/ie/teamchile/smartapp/util/Constants.java
@@ -1,0 +1,9 @@
+package ie.teamchile.smartapp.util;
+
+/**
+ * Created by user on 9/4/15.
+ */
+public interface Constants {
+
+    int SPLASH_TIME_OUT = 2500;      //2.5 seconds
+}

--- a/app/src/main/java/ie/teamchile/smartapp/util/Constants.java
+++ b/app/src/main/java/ie/teamchile/smartapp/util/Constants.java
@@ -6,4 +6,6 @@ package ie.teamchile.smartapp.util;
 public interface Constants {
 
     int SPLASH_TIME_OUT = 2500;      //2.5 seconds
+
+    String SHARED_PREFS_SPLASH_LOG = "splash_log";
 }

--- a/app/src/main/java/ie/teamchile/smartapp/util/SharedPrefs.java
+++ b/app/src/main/java/ie/teamchile/smartapp/util/SharedPrefs.java
@@ -27,12 +27,35 @@ public class SharedPrefs extends BaseActivity {
     public SharedPrefs() {
     }
 
+    public void setLongPrefs(Context context, long data, String tag) {
+        editor = context.getSharedPreferences("SMART", MODE_PRIVATE).edit();
+        editor.putLong(tag, data);
+        editor.commit();
+    }
+
+    public long getLongPrefs(Context context, String tag){
+        prefs = context.getSharedPreferences("SMART", MODE_PRIVATE);
+        long prefsData = prefs.getLong(tag, 0);
+        return prefsData;
+    }
+
+    public void setBooleanPrefs(Context context, boolean data, String tag) {
+        editor = context.getSharedPreferences("SMART", MODE_PRIVATE).edit();
+        editor.putBoolean(tag, data);
+        editor.commit();
+    }
+
+    public boolean getBooleanPrefs(Context context, String tag){
+        prefs = context.getSharedPreferences("SMART", MODE_PRIVATE);
+        boolean prefsData = prefs.getBoolean(tag, false);
+        return prefsData;
+    }
+
     public String getStringPrefs(Context context, String tag){
         prefs = context.getSharedPreferences("SMART", MODE_PRIVATE);
         String prefsData = prefs.getString(tag, "");
         return prefsData;
     }
-
 
     public void setStringPrefs(Context context, String data, String tag) {
         editor = context.getSharedPreferences("SMART", MODE_PRIVATE).edit();

--- a/app/src/main/res/layout/activity_splash_screen.xml
+++ b/app/src/main/res/layout/activity_splash_screen.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:padding="@dimen/padding_default"
+        android:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        android:textSize="20sp"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:orientation="horizontal"
+        android:weightSum="2.0">
+
+        <Button
+            android:id="@+id/btn_yes"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1.0"
+            android:text="Yes"
+            android:theme="@style/CallToActionButton"/>
+
+        <Button
+            android:id="@+id/btn_no"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1.0"
+            android:text="No"
+            android:theme="@style/SecondaryButton"/>
+    </LinearLayout>
+
+</RelativeLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <!-- PADDING -->
+    <dimen name="padding_default">16dp</dimen>
     <dimen name="padding_Xsmall">7dp</dimen>
     <dimen name="padding_small">12dp</dimen>
     <dimen name="padding_medium">20dp</dimen>


### PR DESCRIPTION
This pull request is to add the feature requested in Issue #6 

On first app launch the user is presented with a screen that will contain the relevat text for them to review along with two buttons at the bottom. A positive and negative button styled in the relevant call to action and not call to action used throughout the app.

If the user selects the positive button it will bring them to the login screen. if they select the negative button it will close the app.

Also add a checker to only display this screen if it hasn't already done so in the current day. Can be changed to random times throughout the day.

![device-2015-09-04-221042](https://cloud.githubusercontent.com/assets/10416394/9694579/d5eec170-5351-11e5-82aa-efdd53d3d95a.png)
